### PR TITLE
Makefile, usb_imx: change order of library args, add missing mode to open with create

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,8 @@ $(OBJS): serial.h bsp.h errors.h elf.h
 
 phoenixd: $(OBJS)
 	@echo "LINK" $@
-	$(SIL)$(LD) $(LDFLAGS) -o $@ $(OBJS)
-	
+	$(SIL)$(LD) -o $@ $(OBJS) $(LDFLAGS)
+
 .PHONY: clean
 clean:
 	@echo "CLEAN"

--- a/usb_imx.c
+++ b/usb_imx.c
@@ -419,7 +419,7 @@ int boot_image(char *kernel, char *initrd, char *console, char *append, char *ou
 		}
 		usb_vybrid_dispatch(NULL, (char *)&load_addr, (char *)&jump_addr, image, offset);
 	} else {
-		ifd = open(output, O_RDWR | O_TRUNC | O_CREAT);
+		ifd = open(output, O_RDWR | O_TRUNC | O_CREAT, S_IRUSR | S_IWUSR);
 
 		if (ifd < 0) {
 			printf("Output file open error\n");


### PR DESCRIPTION
Order of library link arguments changed, because gcc on Ubuntu doesn't like it. It's mentioned [here](https://stackoverflow.com/questions/13249610/how-to-use-ldflags-in-makefile#13250090) that on some versions and distros it happens. Open needs to have _mode_ passed when using with _O_CREAT_ or _O_TMPFILE_