### PR TITLE
Change building method to use Makefile.common

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 #
 # Makefile for phoenix-rtos-hostutils
 #
-# Copyright 2018, 2019 Phoenix Systems
+# Copyright 2018-2021 Phoenix Systems
 # Copyright 2001 Pawel Pisarczyk
 #
 # %LICENSE%
@@ -10,69 +10,16 @@
 SIL ?= @
 MAKEFLAGS += --no-print-directory
 
-CC = gcc
-CFLAGS = -c -Wall -I . -O2 -g -I /opt/local/include -I/usr/local/include
-LDFLAGS =
-LD = gcc
-TARGET := host
-STRIP = strip
+TARGET := host-pc
 
-TOPDIR := $(CURDIR)
-PREFIX_BUILD := ../_build/$(TARGET)
-PREFIX_BUILD := $(abspath $(PREFIX_BUILD))
-BUILD_DIR := $(PREFIX_BUILD)/$(notdir $(TOPDIR))
-BUILD_DIR := $(abspath $(BUILD_DIR))
+include ../phoenix-rtos-build/Makefile.common
+include ../phoenix-rtos-build/Makefile.$(TARGET_SUFF)
 
-PREFIX_BOOT := $(realpath "_boot")
-
-# build artifacts dir
-CURR_SUFFIX := $(patsubst $(TOPDIR)/%,%,$(abspath $(CURDIR))/)
-PREFIX_O := $(BUILD_DIR)/$(CURR_SUFFIX)
-
-PREFIX_PROG := $(PREFIX_BUILD)/prog/
-PREFIX_PROG_STRIPPED := $(PREFIX_BUILD)/prog.stripped/
-
-detected_OS := $(shell uname)
-ifeq ($(detected_OS),Linux)
-	LDLIBS := -lhidapi-hidraw
+ifeq ($(UNAME_S),Linux)
+	LDLIBS += -lhidapi-hidraw
 else
-	LDLIBS := `pkg-config --libs hidapi`
+	LDLIBS += `pkg-config --libs hidapi`
 endif
-
-ARCH =  $(SIL)@mkdir -p $(@D); \
-	(printf "AR  %-24s\n" "$(@F)"); \
-	$(AR) $(ARFLAGS) $@ $^ 2>/dev/null
-
-LINK = $(SIL)mkdir -p $(@D); \
-	(printf "LD  %-24s\n" "$(@F)"); \
-	$(LD) $(LDFLAGS) -o "$@"  $^ $(LDLIBS)
-
-HEADER = $(SIL)mkdir -p $(@D); \
-	(printf "HEADER %-24s\n" "$<"); \
-	cp -pR "$<" "$@"
-
-$(PREFIX_O)%.o: %.c
-	@mkdir -p $(@D)
-	$(SIL)(printf "CC  %-24s\n" "$<")
-	$(SIL)$(CC) -c $(CFLAGS) "$<" -o "$@"
-	$(SIL)$(CC) -M  -MP -MF $(PREFIX_O)$*.c.d -MT "$@" $(CFLAGS) $<
-
-$(PREFIX_O)%.o: %.S
-	@mkdir -p $(@D)
-	$(SIL)(printf "ASM %s/%-24s\n" "$(notdir $(@D))" "$<")
-	$(SIL)$(CC) -c $(CFLAGS) "$<" -o "$@"
-	$(SIL)$(CC) -M  -MP -MF $(PREFIX_O)$*.S.d -MT "$@" $(CFLAGS) $<
-
-$(PREFIX_PROG_STRIPPED)%: $(PREFIX_PROG)%
-	@mkdir -p $(@D)
-	@(printf "STR %-24s\n" "$(@F)")
-	$(SIL)$(STRIP) -o $@ $<
-
-include phoenixd/Makefile
-include psu/Makefile
-include psdisk/Makefile
-
-all: $(PREFIX_PROG_STRIPPED)phoenixd $(PREFIX_PROG_STRIPPED)psu $(PREFIX_PROG_STRIPPED)psdisk
 
 .PHONY: clean
 clean:
@@ -80,4 +27,15 @@ clean:
 
 ifneq ($(filter clean,$(MAKECMDGOALS)),)
 	$(shell rm -rf $(BUILD_DIR))
+endif
+
+T1 := $(filter-out clean all,$(MAKECMDGOALS))
+ifneq ($(T1),)
+	include $(T1)/Makefile
+.PHONY: $(T1)
+$(T1): all
+else
+	include phoenixd/Makefile
+	include psu/Makefile
+	include psdisk/Makefile
 endif

--- a/Makefile.old
+++ b/Makefile.old
@@ -1,0 +1,83 @@
+#
+# Makefile for phoenix-rtos-hostutils
+#
+# Copyright 2018, 2019 Phoenix Systems
+# Copyright 2001 Pawel Pisarczyk
+#
+# %LICENSE%
+#
+
+SIL ?= @
+MAKEFLAGS += --no-print-directory
+
+CC = gcc
+CFLAGS = -c -Wall -I . -O2 -g -I /opt/local/include -I/usr/local/include
+LDFLAGS =
+LD = gcc
+TARGET := host-pc
+STRIP = strip
+
+TOPDIR := $(CURDIR)
+PREFIX_BUILD := ../_build/$(TARGET)
+PREFIX_BUILD := $(abspath $(PREFIX_BUILD))
+BUILD_DIR := $(PREFIX_BUILD)/$(notdir $(TOPDIR))
+BUILD_DIR := $(abspath $(BUILD_DIR))
+
+PREFIX_BOOT := $(realpath "_boot")
+
+# build artifacts dir
+CURR_SUFFIX := $(patsubst $(TOPDIR)/%,%,$(abspath $(CURDIR))/)
+PREFIX_O := $(BUILD_DIR)/$(CURR_SUFFIX)
+
+PREFIX_PROG := $(PREFIX_BUILD)/prog/
+PREFIX_PROG_STRIPPED := $(PREFIX_BUILD)/prog.stripped/
+
+detected_OS := $(shell uname)
+ifeq ($(detected_OS),Linux)
+	LDLIBS := -lhidapi-hidraw
+else
+	LDLIBS := `pkg-config --libs hidapi`
+endif
+
+ARCH =  $(SIL)@mkdir -p $(@D); \
+	(printf "AR  %-24s\n" "$(@F)"); \
+	$(AR) $(ARFLAGS) $@ $^ 2>/dev/null
+
+LINK = $(SIL)mkdir -p $(@D); \
+	(printf "LD  %-24s\n" "$(@F)"); \
+	$(LD) $(LDFLAGS) -o "$@"  $^ $(LDLIBS)
+
+HEADER = $(SIL)mkdir -p $(@D); \
+	(printf "HEADER %-24s\n" "$<"); \
+	cp -pR "$<" "$@"
+
+$(PREFIX_O)%.o: %.c
+	@mkdir -p $(@D)
+	$(SIL)(printf "CC  %-24s\n" "$<")
+	$(SIL)$(CC) -c $(CFLAGS) "$<" -o "$@"
+	$(SIL)$(CC) -M  -MP -MF $(PREFIX_O)$*.c.d -MT "$@" $(CFLAGS) $<
+
+$(PREFIX_O)%.o: %.S
+	@mkdir -p $(@D)
+	$(SIL)(printf "ASM %s/%-24s\n" "$(notdir $(@D))" "$<")
+	$(SIL)$(CC) -c $(CFLAGS) "$<" -o "$@"
+	$(SIL)$(CC) -M  -MP -MF $(PREFIX_O)$*.S.d -MT "$@" $(CFLAGS) $<
+
+$(PREFIX_PROG_STRIPPED)%: $(PREFIX_PROG)%
+	@mkdir -p $(@D)
+	@(printf "STR %-24s\n" "$(@F)")
+	$(SIL)$(STRIP) -o $@ $<
+
+include phoenixd/Makefile
+include psu/Makefile
+include psdisk/Makefile
+
+all: $(PREFIX_PROG_STRIPPED)phoenixd $(PREFIX_PROG_STRIPPED)psu $(PREFIX_PROG_STRIPPED)psdisk
+
+.PHONY: clean
+clean:
+	@echo "rm -rf $(BUILD_DIR)"
+
+ifneq ($(filter clean,$(MAKECMDGOALS)),)
+	$(shell rm -rf $(BUILD_DIR))
+endif


### PR DESCRIPTION
I preserve old Makefile for build by phoenix-rtos-build/build.sh script. More info in:
https://github.com/phoenix-rtos/phoenix-rtos-build/pull/40
Notable change: target host changed to host-pc to conform with TARGET_FAMILY-TARGET_SUBFAMILY style.