### PR TITLE
phoenixd: Allow calling phoenixd without initrd argument

### DIFF
--- a/common/usb_imx.c
+++ b/common/usb_imx.c
@@ -392,7 +392,7 @@ static int count_sysprogs(char *initrd, char *console, char *append, int *syspro
 
 		cnt++;
 		if ((pfd = open(prog, O_RDONLY)) < 0) {
-			fprintf(stderr, "Could not open file %s\n", initrd);
+			fprintf(stderr, "Could not open file %s\n", prog);
 			goto next;
 		}
 
@@ -429,7 +429,7 @@ static int append_sysprogs(void *image, char *initrd, char *console, char *appen
 		syspage->progs[i].start = offset + addr;
 
 		if ((pfd = open(prog, O_RDONLY)) < 0) {
-			fprintf(stderr, "Can't open initrd file %s\n", initrd);
+			fprintf(stderr, "Could not open file %s\n", prog);
 			goto next;
 		}
 

--- a/phoenixd/phoenixd.c
+++ b/phoenixd/phoenixd.c
@@ -250,8 +250,8 @@ int main(int argc, char *argv[])
 	}
 
 	if (output) {
-		if (kernel == NULL || initrd == NULL) {
-			fprintf(stderr, "Output file needs kernel and initrd paths\n");
+		if (kernel == NULL) {
+			fprintf(stderr, "Output file needs kernel path\n");
 			return -1;
 		}
 		res = boot_image(kernel, initrd, console, append, output, sdp == 2 ? 1 : 0);


### PR DESCRIPTION
Since syspage programs are already a part of kernel image, there is
no need for appending them using phoenixd. Calling phoenixd with 'output'
and 'kernel' parameters should be used in order to set syspage programs
physical address and kernel arguments. This is still used in imx6ull
target.

An example of a call to phoenixd, which is allowed thanks to this commit:
`$PREFIX_BOOT/phoenixd --plugin --kernel $KERNEL_IMG="Ximx6ull-uart Ximx6ull-flash;-p;64;64;-r;jffs2;0;-p;128;64;-p;192;1856;-p;4032;16 Xpsh;-i;/etc/rc.psh" --output $PREFIX_BOOT/primary.img`

It generates a new kernel image containing a kernel plugin needed by the imx6ull bootloader and a valid syspage structure
with given kernel command line arguments.