### PR TITLE
hostutils/phoenixd: break from loop after connection lost on port

### DIFF
--- a/phoenixd/dispatch.c
+++ b/phoenixd/dispatch.c
@@ -111,7 +111,7 @@ int dispatch(char *dev_addr, dmode_t mode, char *sysdir, void *data)
 				usleep(100000);
 				(void) connect_pipes(dev_in, dev_out, &fd, &fd_out);
 			}
-			continue;
+			break;
 		}
 		fprintf(stderr, "[%d] dispatch: Message received\n", getpid());
 


### PR DESCRIPTION
JIRA: PD-29

phoenixd closes itself after connection lost

## Description
break from loop in message dispatch in phoenixd

## Motivation and Context
This change allows for further automation of development process. User may create a bash script that rapidly runs the phoenixd, thus user does not have to "aim" with phoenixd when plo starts.

Change allows easy "run in background" for phoenixd 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: imxrt1064.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
