### PR TITLE
psdisk: remove warnings from strncpy

### DIFF
--- a/psdisk/psdisk.c
+++ b/psdisk/psdisk.c
@@ -409,7 +409,7 @@ static int psdisk_parseToRm(void)
 		return -1;
 	}
 	else {
-		strncpy((char *)pNode->pHeader.name, optarg, strlen(optarg));
+		strncpy((char *)pNode->pHeader.name, optarg, sizeof(pNode->pHeader.name));
 	}
 
 	pNode->status = part_remove;
@@ -477,7 +477,7 @@ static int psdisk_parseToSave(void)
 			break;
 		}
 		else {
-			strncpy((char *)pNode->pHeader.name, opts[0], strlen(opts[0]));
+			strncpy((char *)pNode->pHeader.name, opts[0], sizeof(pNode->pHeader.name));
 		}
 
 		if (((pNode->pHeader.offset = strtoul(opts[1], &endptr, 0)) == 0 && strlen(endptr) != 0) || (pNode->pHeader.offset != 0 && strlen(endptr) != 0)) {


### PR DESCRIPTION
JIRA: RTOS-61

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Changed `count` value in `strncpy` function. Instead of using a source's size, there is used a max size of destination string. If the source's size is shorter than `count`, the `strncpy` will add a null character to the destination string.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The following change removes warnings which appear in gcc version > 9. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [x] I will merge this PR by myself when appropriate.
