### PR TITLE
psu: correct last sent packet size

### DIFF
--- a/psu/psu.c
+++ b/psu/psu.c
@@ -163,7 +163,17 @@ static int sdp_writeFile(hid_device *dev, uint32_t addr, void *data, size_t size
 		/* Report 2 size has to be aligned to 16, information define in HID Report Descriptor - ID 2 */
 		if (n % 0x10) {
 			memset(b + 1 + n, 0, ((n + 0xf) & ~0xf) - n);
-			n = (n + 0xf) & ~0xf;
+
+			/* Last packet has to be smaller */
+			if ((n = (n + 0xf) & ~0xf) == BUF_SIZE - 1) {
+				if ((rc = hid_write(dev, b, n + 1)) < 0) {
+					fprintf(stderr, "\nFailed to send image contents (rc=%d)\n", rc);
+					return SCRIPT_ERROR;
+				}
+
+				n = 0x10;
+				memset(b + 1, 0, n);
+			}
 		}
 
 		if ((rc = hid_write(dev, b, n + 1)) < 0) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The last sent packet size can't be aligned to 1024 bytes. In that case send extra 16 bytes in another packet.

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
psu hangs if the last packet gets aligned 1024 bytes.
[JIRA: RTOS-70](https://jira.phoenix-rtos.com/browse/RTOS-70)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: ia32-generic.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
