### PR TITLE
psdisk, metaelf: changes to allow building on MacOS

### DIFF
--- a/metaelf/Makefile
+++ b/metaelf/Makefile
@@ -4,7 +4,11 @@
 # Copyright 2022 Phoenix Systems
 #
 
+ifneq ($(shell uname), Darwin)
+
 $(PREFIX_PROG)metaelf: $(addprefix $(PREFIX_O)metaelf/,crc32.o metaelf.o)
 	$(LINK)
 
 all: $(PREFIX_PROG_STRIPPED)metaelf
+
+endif

--- a/psdisk/psdisk.c
+++ b/psdisk/psdisk.c
@@ -21,6 +21,13 @@
 #include <sys/stat.h>
 #include <sys/queue.h>
 
+/* le32toh() and  not defined on MacOS */
+#ifdef __APPLE__
+
+#include <libkern/OSByteOrder.h>
+#define le32toh(x) OSSwapLittleToHostInt32(x)
+
+#endif
 
 /* TODO: change access to ptable.h */
 #include "../../phoenix-rtos-corelibs/libptable/ptable.h"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

 - metaelf: temporarily disable on MacOS
 - psdisk: redefine endian functions on MacOS

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

elf.h header is not available on MacOS.

le32toh() and htole32() are not available on MacOS. Including sys/endian.h or machine/endian.h does not help in this case. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (MacOS - building various targets).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
