### PR TITLE
psu: fix check for invalid timeout value

### DIFF
--- a/psu/psu.c
+++ b/psu/psu.c
@@ -785,7 +785,7 @@ int main(int argc, char *argv[])
 
 			case 't':
 				tmp = strtol(optarg, &ptr, 10);
-				if ((optarg == ptr) || (tmp < 0) || (tmp > INT_MAX)) {
+				if ((optarg == ptr) || (*ptr != '\0') || (tmp < 0) || (tmp > INT_MAX)) {
 					fprintf(stderr, "Invalid timeout value\n");
 					usage(argv[0]);
 					return EXIT_FAILURE;


### PR DESCRIPTION
Quick fix for https://github.com/phoenix-rtos/phoenix-rtos-hostutils/pull/45#discussion_r1241262716

Fixes invalid value detection case, e.g.:
`psu -t 10abc script.plo`
`psu -t "10 xyz 1234" script.plo`

Distinguishes as an error:
`psu -t "" script.plo`

JIRA: RTOS-510

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
