### PR TITLE
mkrofs: Workaround GCC 15.2 issue with sanitizers

### DIFF
--- a/mkrofs/mkrofs.c
+++ b/mkrofs/mkrofs.c
@@ -219,7 +219,14 @@ static void basestrncpy(char *dst, const char *src, size_t len)
 		exit(EXIT_FAILURE);
 	}
 	tmp = basename(strcpy((char *)common.buf, src));
-
+	/*
+	 * NOTE: According to basename documentation and implementation, should never happen. Required due to GCC 15.2
+	 * See: https://github.com/phoenix-rtos/phoenix-rtos-project/issues/1477
+	 */
+	if (tmp == NULL) {
+		ERR("unexpected error");
+		exit(EXIT_FAILURE);
+	}
 	size_t tmplen = strlen(tmp);
 	if (tmplen >= len) {
 		ERR("Name '%s' will be trimmed to %zu characters", tmp, len);


### PR DESCRIPTION
Due to compiler false-positive, build not working with enabled sanitizers and optimization level >= -O2. To workaround this, explicit check is required.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Description in linked issue
FIXES: https://github.com/phoenix-rtos/phoenix-rtos-project/issues/1477

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: build&test on host-generic-pc

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
