### PR TITLE
common: Fix build with std=gnu23

### DIFF
--- a/common/script.c
+++ b/common/script.c
@@ -316,7 +316,7 @@ static int _script_parse_cmp(const void *k, const void *e)
 /* main loop of the psu script parser */
 int script_parse(script_t *s, int flags)
 {
-	script_funct_t *p;
+	const script_funct_t *p;
 
 	s->errstr = NULL;
 	s->flags = flags;


### PR DESCRIPTION
Ubuntu 26.04 set default standard for gcc to gnu23, which have stricter rules about values returned by bsearch

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
```
/path/to/phoenix-rtos-project/phoenix-rtos-hostutils/common/script.c: In function ‘script_parse’:
/path/to/phoenix-rtos-project/phoenix-rtos-hostutils/common/script.c:349:32: error: assignment discards ‘const’ qualifier from pointer target type [-Werror=discarded-qualifiers]
  349 |                         if ((p = bsearch(s, s->pfuncs, s->nfuncs, sizeof(*s->pfuncs), _script_parse_cmp))) {
      |                                ^
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: build on ia32-generic-qemu, with Ubuntu 26.04

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [x] I will merge this PR by myself when appropriate.
